### PR TITLE
Move Membership Requires and Voting Rules to Policy Document

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -112,9 +112,8 @@ Subject to and within the limits of \ref{genpurp}, the corporation shall:
 \subsection{Basic Membership Election}
 
 Any person who supports the purposes laid out in \ref{whyweexist} of
-these bylaws is qualified to become a basic member.  Any qualified person
-may be elected a basic member upon payment of appropriate dues and by a simple
-majority of a quorum of voting members.
+these bylaws is qualified to become a basic member. Membership requirements and 
+voting procedures are listed in the \emph{policy document}.
 
 
 \subsection{Voting Membership Election}

--- a/policy.tex
+++ b/policy.tex
@@ -67,6 +67,48 @@
 \tableofcontents
 \newpage
 
+\section{Membership}
+This policy outlines the requirements of new members, and defines the method by 
+which new member applications are accepted.
+
+\subsection{Membership Requirements}
+
+Any person meeting these requirements are eligible for membership:
+\begin{itemize}
+    \item 18 years or older
+    \item Willing to provide documents listed in \ref{memberdocs}
+\end{itemize}
+
+\subsection{Voting}
+After an application is submitted, the Secretary shall send a notice to the 
+Voting Members in a timely fashion. Voting Members shall have one (1) week from 
+the date of notice to vote on the application. Votes shall be recorded by the 
+Secretary, and may be submitted either in person or electronically.
+
+For the purposes of voting on applications, quorum shall be defined as having at
+least one half of the Voting Membership submitting a vote during the voting 
+period.
+
+If quorum has been met, then a simple majority of votes submitted are needed for
+an application to be approved.
+
+If quorum was not met, then the application may be resubmitted to the Voting 
+Membership at the Secretary's discretion.
+
+\subsection{Required Documents}
+\label{memberdocs}
+
+New members must provide the following before they are granted access to any 
+physical locations.
+
+\begin{itemize}
+    \item Signed Policy Waiver
+    \item Copy of valid proof of identity: drivers license or state/federal ID 
+    card
+    \item Provide current address, phone number, and emergency contact 
+    information
+\end{itemize}
+
 \section{Membership Dues}
 \label{dues}
 


### PR DESCRIPTION
Bylaw change to move membership requirements and voting procedure to the Policy Documents. New policy created to allow for electronic voting on applications, and to list required documentation.