### PR TITLE
Revoke membership vs. Terminated

### DIFF
--- a/bylaws.tex
+++ b/bylaws.tex
@@ -184,7 +184,7 @@ Any suspended member may restore their membership up to 90 days after
 suspension upon payment of dues owed and payable through one month beyond the
 end of the suspension period.
 Once the 90 days of non-payment have passed, the membership is automatically
-terminated.
+revoked for non-payment of dues, reapplication is required to regain membership.
 Any membership may also be terminated for any reason by written petition
 signed by more than three quarters of the voting members.
 


### PR DESCRIPTION
Reserve "Terminated" for member removed by written petition of voting members.

New "Terminated" usage lines up with the membership lifecycle document.